### PR TITLE
vendor/bin がシンボリックリンクじゃなくなっても動くようにする

### DIFF
--- a/bin/awsps
+++ b/bin/awsps
@@ -1,7 +1,7 @@
 #!/usr/bin/php
 <?php
 
-foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
+foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../autoload.php'] as $file) {
     if (file_exists($file)) {
         include_once $file;
         break;

--- a/bin/awsps
+++ b/bin/awsps
@@ -1,6 +1,11 @@
 #!/usr/bin/php
 <?php
 
-include_once __DIR__.'/../../../autoload.php';
+foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
+    if (file_exists($file)) {
+        include_once $file;
+        break;
+    }
+}
 
 \Uenoryo\Awsps\Command::exec($argv);


### PR DESCRIPTION
## Issue

> CLIで実行すると autoload.php が読み込まれない

#2 

調査結果
https://github.com/uenoryo/php-awsps/issues/2#issuecomment-489307566

## 内容

autoload.php への path を2パターン想定してロードするように修正した


## 動作確認

**修正前**

```sh
$ mkdir sandbox
$ cd sandbox
$ composer init
$ composer require uenoryo/php-awsps
$ ./vendor/bin/awsps
// 動作する
Usage: awsps [options...]
...

// 実態をコピー
$ unlink vendor/bin/awsps
$ cp ./vendor/uenoryo/php-awsps/bin/awsps ./vendor/bin/awsps
$ ./vendor/bin/awsps

Warning: include_once(/Users/ryo/dev/sandbox/php/sandbox/vendor/bin/../../../autoload.php): failed to open stream: No such file or directory in /Users/ryo/dev/sandbox/php/sandbox/vendor/bin/awsps on line 4
死
```

**修正後**

修正後を突っ込んでみる

```patch
     "require": {
-        "uenoryo/php-awsps": "^1.4"
+        "uenoryo/php-awsps": "dev-master#99f71a157c34d52a4ec836795d28c4de2de2ca6e"
     }
```


動く

```sh
$ ./vendor/bin/awsps
Usage: awsps [options...]
```

実態をコピーしても動く

```sh
$ unlink vendor/bin/awsps
$ cp ./vendor/uenoryo/php-awsps/bin/awsps ./vendor/bin/awsps
$ ./vendor/bin/awsps
Usage: awsps [options...]
```