### PR TITLE
json_encodeするときにスラッシュのエスケープはオプショナルにする

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -40,7 +40,7 @@ class Client
         ]);
         $client->path = $config->path;
         $client->validateSelf();
-        $client->setExporter($config->exportType);
+        $client->setExporter($config->exportType, $config->escapeSlush);
         return $client;
     }
 
@@ -109,7 +109,7 @@ class Client
      *
      * @return Uenoryo\Awsps\Client
      */
-    public function setExporter(string $type)
+    public function setExporter(string $type, bool $escapeSlush = false)
     {
         switch (true) {
             case $type === '' || $type === 'plain' || $type === 'Plain':
@@ -117,6 +117,9 @@ class Client
                 break;
             case $type === 'json' || $type === 'Json':
                 $this->exporter = new Json;
+                if ($escapeSlush) {
+                    $this->exporter->escapeSlush = true;
+                }
                 break;
             default:
                 throw new Exception("Invalid export type:'{$type}'");

--- a/src/Client.php
+++ b/src/Client.php
@@ -109,7 +109,7 @@ class Client
      *
      * @return Uenoryo\Awsps\Client
      */
-    public function setExporter(string $type, bool $escapeSlush = false)
+    public function setExporter(string $type, ?bool $escapeSlush = false)
     {
         switch (true) {
             case $type === '' || $type === 'plain' || $type === 'Plain':

--- a/src/Command.php
+++ b/src/Command.php
@@ -28,10 +28,18 @@ class Command
         $config->path = $args[2];
         if (isset($args[3])) {
             if ($args[3] !== '--json') {
-                echo "Error: $msg run [awsps --help] for more information.".PHP_EOL;
+                echo "Error: invalid option. run [awsps --help] for more information.".PHP_EOL;
                 die();
             }
             $config->exportType = 'json';
+
+            if (isset($args[4])) {
+                if ($args[4] !== '--escape-slush') {
+                    echo "Error: invalid option. run [awsps --help] for more information.".PHP_EOL;
+                    die();
+                }
+                $config->escapeSlush = true;
+            }
         }
 
         $client = Client::new($config);
@@ -45,6 +53,7 @@ class Command
         echo 'Usage: awsps [options...]'.PHP_EOL.PHP_EOL;
         echo '--help            Show this help'.PHP_EOL;
         echo '--json            Export JSON format'.PHP_EOL;
+        echo '--escape-slush    Escape slush when export JSON format'.PHP_EOL;
         echo '--path <path>     Target path of AWS Parameter store'.PHP_EOL.PHP_EOL;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,6 +16,9 @@ class Config
     /* @var export type */
     public $exportType = '';
 
+    /* @var escape slush when encode to json */
+    public $escapeSlush = false;
+
     public static function new()
     {
         return new Self;

--- a/src/Exporter/Json.php
+++ b/src/Exporter/Json.php
@@ -6,12 +6,22 @@ use Uenoryo\Awsps\Exporter;
 
 class Json implements Exporter
 {
+	public $noEscape = false;
+
 	public function export($data)
 	{
 		$result = [];
 		foreach ($data as $r) {
 			$result[$r->name] = $r->value;
 		}
-		return json_encode($result);
+
+		$options = [];
+		if ($this->noEscape) {
+			$options = [
+				JSON_UNESCAPED_SLASHES,
+				JSON_UNESCAPED_UNICODE,
+			];
+		}
+		return json_encode($result, $options);
 	}
 }

--- a/src/Exporter/Json.php
+++ b/src/Exporter/Json.php
@@ -6,7 +6,7 @@ use Uenoryo\Awsps\Exporter;
 
 class Json implements Exporter
 {
-	public $noEscape = false;
+	public $escapeSlush = false;
 
 	public function export($data)
 	{
@@ -15,13 +15,10 @@ class Json implements Exporter
 			$result[$r->name] = $r->value;
 		}
 
-		$options = [];
-		if ($this->noEscape) {
-			$options = [
-				JSON_UNESCAPED_SLASHES,
-				JSON_UNESCAPED_UNICODE,
-			];
+		$option = null;
+		if (! $this->escapeSlush) {
+			$option = JSON_UNESCAPED_SLASHES;
 		}
-		return json_encode($result, $options);
+		return json_encode($result, $option);
 	}
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -93,28 +93,38 @@ class ClientTest extends TestCase
     {
         $tests = [
         	[
-	        	'title'  => 'success case: json',
-	        	'input'  => 'Json',
-	        	'expect' => 'Uenoryo\Awsps\Exporter\Json',
-	        	'error'  => null,
+	        	'title'        => 'success case: json, no escape slush',
+	        	'input'        => 'Json',
+                'escape_slush' => false,
+	        	'expect'       => 'Uenoryo\Awsps\Exporter\Json',
+	        	'error'        => null,
+        	],
+            [
+                'title'        => 'success case: json, escape slush',
+                'input'        => 'Json',
+                'escape_slush' => true,
+                'expect'       => 'Uenoryo\Awsps\Exporter\Json',
+                'error'        => null,
+            ],
+        	[
+	        	'title'       => 'success case: plain',
+	        	'input'       => 'Plain',
+	        	'expect'      => 'Uenoryo\Awsps\Exporter\Plain',
+	        	'error'       => null,
         	],
         	[
-	        	'title'  => 'success case: plain',
-	        	'input'  => 'Plain',
-	        	'expect' => 'Uenoryo\Awsps\Exporter\Plain',
-	        	'error'  => null,
+	        	'title'        => 'success case :default',
+	        	'input'        => '',
+                'escape_slush' => false,
+	        	'expect'       => 'Uenoryo\Awsps\Exporter\Plain',
+	        	'error'        => null,
         	],
         	[
-	        	'title'  => 'success case :default',
-	        	'input'  => '',
-	        	'expect' => 'Uenoryo\Awsps\Exporter\Plain',
-	        	'error'  => null,
-        	],
-        	[
-	        	'title'  => 'error case, invalid exporter type',
-	        	'input'  => 'invalid type',
-	        	'expect' => null,
-	        	'error'  => Exception::class,
+	        	'title'        => 'error case, invalid exporter type',
+	        	'input'        => 'invalid type',
+                'escape_slush' => false,
+	        	'expect'       => null,
+	        	'error'        => Exception::class,
         	],
         ];
 
@@ -130,8 +140,12 @@ class ClientTest extends TestCase
         		continue;
         	}
 
-        	$client->setExporter($t['input']);
+        	$client->setExporter($t['input'], $t['escape_slush'] ?? null);
         	$this->assertSame($t['expect'], get_class($client->exporter), $t['title']);
+
+            if ($t['input'] === 'Json') {
+                $this->assertSame($t['escape_slush'], $client->exporter->escapeSlush, $t['title']);
+            }
         }
     }
 

--- a/tests/Exporter/JsonTest.php
+++ b/tests/Exporter/JsonTest.php
@@ -12,33 +12,54 @@ class ClientTest extends TestCase
     public function testExport()
     {
         $tests = [
-        	[
-	        	'title' => 'success case',
-	        	'init' => function() {
-	        		$param1 = new Param();
-	        		$param1->name  = 'Dummy1';
-	        		$param1->value = 'dummy1';
+            [
+                'title'        => 'success case',
+                'escape_slush' => false,
+                'init' => function() {
+                    $param1 = new Param();
+                    $param1->name  = 'Dummy1';
+                    $param1->value = 'dummy1';
 
-	        		$param2 = new Param();
-	        		$param2->name  = 'Dummy2';
-	        		$param2->value = 'dummy2';
+                    $param2 = new Param();
+                    $param2->name  = 'Dummy2';
+                    $param2->value = 'dummy2';
 
-	        		$param3 = new Param();
-	        		$param3->name  = 'Dummy3';
-	        		$param3->value = 'dummy3';
+                    $param3 = new Param();
+                    $param3->name  = 'Dummy3';
+                    $param3->value = 'd/u/m/m/y//3';
 
-	        		return [$param1, $param2, $param3];
-	        	},
-	        	'expect' => '{"Dummy1":"dummy1","Dummy2":"dummy2","Dummy3":"dummy3"}',
-        	],
+                    return [$param1, $param2, $param3];
+                },
+                'expect' => '{"Dummy1":"dummy1","Dummy2":"dummy2","Dummy3":"d/u/m/m/y//3"}',
+            ],
+            [
+                'title'        => 'success case, escape slush',
+                'escape_slush' => true,
+                'init' => function() {
+                    $param1 = new Param();
+                    $param1->name  = 'Dummy1';
+                    $param1->value = 'dummy1';
+
+                    $param2 = new Param();
+                    $param2->name  = 'Dummy2';
+                    $param2->value = 'dummy2';
+
+                    $param3 = new Param();
+                    $param3->name  = 'Dummy3';
+                    $param3->value = 'd/u/m/m/y//3';
+
+                    return [$param1, $param2, $param3];
+                },
+                'expect' => '{"Dummy1":"dummy1","Dummy2":"dummy2","Dummy3":"d\/u\/m\/m\/y\/\/3"}',
+            ],
         ];
 
         foreach ($tests as $t) {
-        	$client = Client::new(Config::new());
-        	$client->setExporter('json');
-        	$client->params = $t['init']();
+            $client = Client::new(Config::new());
+            $client->setExporter('json', $t['escape_slush']);
+            $client->params = $t['init']();
 
-        	$this->assertSame($t['expect'], $client->export(), $t['title']);
+            $this->assertSame($t['expect'], $client->export(), $t['title']);
         }
     }
 }


### PR DESCRIPTION
## 背景

取得した値のスラッシュがエスケープされる仕様だったが
エスケープされると困ることがある

## 内容

デフォルトはスラッシュをエスケープしないようにした

エスケープさせたい場合は `--escape-slush` オプションをつけるようにした

## 確認

```sh

$ ./bin/awsps --path /Path/To/Example --json
{"APP_KEY":"https://hogehoge.com/"}

$ ./bin/awsps --path /Path/To/Example --json --escape-slush
{"APP_KEY":"https:\/\/hogehoge.com\/"}
```